### PR TITLE
Use DateTimeInterface to support DateTimeImmutable

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Custom GraphQL Scalars for creating precise type-safe GraphQL schemas.
 Requirements
 ------------
 
--   PHP 7.0+
+-   PHP 7.2+
 -   [PHP Webonyx GraphQL](https://github.com/webonyx/graphql-php)
 
 
@@ -41,7 +41,7 @@ This scalar is a description of the date, as used for birthdays for example. It 
 The `DateTime` scalar type represents time data, represented as an [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601) encoded UTC date string.
 
 #### Result Coercion
-PHP `DateTime` instances are coerced to an `DateTime::ATOM` (RFC 3339) compliant date string.
+PHP `DateTime` or `DateTimeImmutable` instances are coerced to a `DateTimeInterface::ATOM` (RFC 3339) compliant date string.
 
 #### Input Coercion
 When expected as an input type, most of valid ISO-8601 compliant date strings are accepted.

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   ],
   "minimum-stability": "stable",
   "require": {
-    "php": ">=7.0"
+    "php": ">=7.2"
   },
   "autoload": {
     "psr-4": {

--- a/src/Type/DateTimeType.php
+++ b/src/Type/DateTimeType.php
@@ -17,10 +17,12 @@ declare(strict_types=1);
 namespace Stagem\GraphQL\Type;
 
 use DateTime;
+use DateTimeInterface;
 use GraphQL\Error\Error;
 use GraphQL\Language\AST\StringValueNode;
 use GraphQL\Language\AST\Node;
 use GraphQL\Type\Definition\ScalarType;
+use GraphQL\Utils\Utils;
 
 /**
  * Represent native PHP DateTime
@@ -39,13 +41,20 @@ class DateTimeType extends ScalarType
      */
     public $description = 'The `DateTime` scalar type represents time data, represented as an ISO-8601 encoded UTC date string.';
 
+    /**
+     * Serializes an internal value to include in a response.
+     *
+     * @param mixed $value
+     * @return mixed
+     * @throws Error If the provided value does not implement DateTimeInterface.
+     */
     public function serialize($value)
     {
-        if ($value instanceof DateTime) {
-            return $value->format(DateTime::ATOM);
+        if (!($value instanceof DateTimeInterface)) {
+            throw new Error(sprintf('DateTime cannot represent non DateTime value: %s', Utils::printSafe($value)));
         }
 
-        return $value;
+        return $value->format(DateTimeInterface::ATOM);
     }
 
     /**
@@ -81,7 +90,7 @@ class DateTimeType extends ScalarType
         $results[] = DateTime::createFromFormat('Y-m-d\TH:i:s.u', $iso8601String);
         $results[] = DateTime::createFromFormat('Y-m-d\TH:i:s.uP', $iso8601String);
         $results[] = DateTime::createFromFormat('Y-m-d\TH:i:sP', $iso8601String);
-        $results[] = DateTime::createFromFormat(DateTime::ATOM, $iso8601String);
+        $results[] = DateTime::createFromFormat(DateTimeInterface::ATOM, $iso8601String);
 
         $success = array_values(array_filter($results));
         if (count($success) > 0) {
@@ -91,5 +100,3 @@ class DateTimeType extends ScalarType
         return false;
     }
 }
-
-

--- a/src/Type/DateType.php
+++ b/src/Type/DateType.php
@@ -17,10 +17,12 @@ declare(strict_types=1);
 namespace Stagem\GraphQL\Type;
 
 use DateTime;
+use DateTimeInterface;
 use GraphQL\Error\Error;
 use GraphQL\Language\AST\StringValueNode;
 use GraphQL\Language\AST\Node;
 use GraphQL\Type\Definition\ScalarType;
+use GraphQL\Utils\Utils;
 
 /**
  * Represent native PHP DateTime
@@ -40,13 +42,20 @@ class DateType extends ScalarType
      */
     public $description = 'The `Date` scalar type represents date data in format "2012-12-31"';
 
+    /**
+     * Serializes an internal value to include in a response.
+     *
+     * @param mixed $value
+     * @return mixed
+     * @throws Error If the provided value does not implement DateTimeInterface.
+     */
     public function serialize($value)
     {
-        if ($value instanceof DateTime) {
-            return $value->format(self::DATE_FORMAT);
+        if (!($value instanceof DateTimeInterface)) {
+            throw new Error(sprintf('Date cannot represent non DateTime value: %s', Utils::printSafe($value)));
         }
 
-        return $value;
+        return $value->format(self::DATE_FORMAT);
     }
 
     /**
@@ -77,5 +86,3 @@ class DateType extends ScalarType
         return $valueNode->value;
     }
 }
-
-

--- a/src/Type/TimeType.php
+++ b/src/Type/TimeType.php
@@ -17,10 +17,12 @@ declare(strict_types=1);
 namespace Stagem\GraphQL\Type;
 
 use DateTime;
+use DateTimeInterface;
 use GraphQL\Error\Error;
 use GraphQL\Language\AST\Node;
 use GraphQL\Language\AST\StringValueNode;
 use GraphQL\Type\Definition\ScalarType;
+use GraphQL\Utils\Utils;
 
 class TimeType extends ScalarType
 {
@@ -40,16 +42,17 @@ class TimeType extends ScalarType
      *
      * @param mixed $value
      * @return mixed
-     * @throws Error
+     * @throws Error If the provided value does not implement DateTimeInterface.
      */
     public function serialize($value)
     {
-        if ($value instanceof DateTime) {
-            return $value->format(self::TIME_FORMAT);
+        if (!($value instanceof DateTimeInterface)) {
+            throw new Error(sprintf('Date cannot represent non DateTime value: %s', Utils::printSafe($value)));
         }
 
-        return $value;
+        return $value->format(self::TIME_FORMAT);
     }
+
     /**
      * Parses an externally provided value (query variable) to use as an input
      * In the case of an invalid value this method must throw an Exception


### PR DESCRIPTION
I use DateTimeImmutable in my application. This PR adds support for DateTimeImmutable by using DateTimeInterface instead of DateTime.

I upgraded the minimum PHP version to 7.2 to support the new DateTimeInterface constants.

The code now throws an error when serialize is called with a bad value, just like other types do.